### PR TITLE
Move root logger config to CLI module

### DIFF
--- a/src/pms/__init__.py
+++ b/src/pms/__init__.py
@@ -1,7 +1,5 @@
 import logging
-import os
 
-logging.basicConfig(level=os.getenv("LEVEL", "WARNING"))
 logger = logging.getLogger(__name__)
 
 

--- a/src/pms/cli.py
+++ b/src/pms/cli.py
@@ -1,3 +1,5 @@
+import logging
+import os
 import sys
 from datetime import datetime
 from enum import Enum
@@ -25,6 +27,9 @@ for ep in metadata.entry_points(group="pypms.extras"):
     main.command(name=ep.name)(ep.load())
 
 
+logging.basicConfig(level=os.getenv("LEVEL", "WARNING"))
+
+
 def version_callback(value: bool):  # pragma: no cover
     if not value:
         return
@@ -45,8 +50,7 @@ def callback(
     version: Optional[bool] = Option(None, "--version", "-V", callback=version_callback),
 ):
     """Read serial sensor"""
-    if debug:  # pragma: no cover
-        logger.setLevel("DEBUG")
+    logger.setLevel("DEBUG" if debug else os.getenv("LEVEL", "WARNING"))
     ctx.obj = {"reader": SensorReader(model, port, seconds, samples)}
 
 

--- a/src/pms/cli.py
+++ b/src/pms/cli.py
@@ -131,3 +131,7 @@ def csv(
                 csv.write("time,sensor,hex\n")
             for raw in reader(raw=True):
                 csv.write(f"{raw.time},{sensor_name},{raw.hex}\n")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
Fixes: https://github.com/avaldebe/PyPMS/issues/27.

This ensures the root logger is only configured when 
this package is used as a command.

I've also added an extra commit to support local dev - 
happy to learn if there's a way of doing it already.