### PR TITLE
Favour "data" over "raw" in ObsData tests

### DIFF
--- a/tests/sensors/test_obsdata.py
+++ b/tests/sensors/test_obsdata.py
@@ -12,9 +12,9 @@ from pms.sensors.winsen import mhz19b, zh0xx
 
 
 @pytest.mark.parametrize("fmt", "header csv pm num cf raw error".split())
-def test_PMSx003_format(fmt, raw=tuple(range(1, 13)), secs=1_567_198_523, sensor=pmsx003):
-    obs = sensor.ObsData(secs, *raw)
-    raw = raw[:6] + tuple(x / 100 for x in raw[6:])
+def test_PMSx003_format(fmt, data=tuple(range(1, 13)), secs=1_567_198_523, sensor=pmsx003):
+    obs = sensor.ObsData(secs, *data)
+    data = data[:6] + tuple(x / 100 for x in data[6:])
     obs_fmt = dict(
         raw="{0}: PM1 {1:d}, PM2.5 {2:d}, PM10 {3:d} μg/m3",
         pm="{0}: PM1 {4:.1f}, PM2.5 {5:.1f}, PM10 {6:.1f} μg/m3",
@@ -22,15 +22,17 @@ def test_PMSx003_format(fmt, raw=tuple(range(1, 13)), secs=1_567_198_523, sensor
     )
     date = time.strftime("%F %T", time.localtime(secs))
     if fmt in obs_fmt:
-        assert f"{obs:{fmt}}" == obs_fmt[fmt].format(date, *raw)
+        assert f"{obs:{fmt}}" == obs_fmt[fmt].format(date, *data)
     elif fmt == "header":
         assert f"{obs:{fmt}}" == ", ".join(asdict(obs).keys())
     elif fmt == "csv":
         csv = "{}, {:d}, {:d}, {:d}, {:.1f}, {:.1f}, {:.1f}, {:.2f}, {:.2f}, {:.2f}, {:.2f}, {:.2f}, {:.2f}"
-        assert f"{obs:{fmt}}" == csv.format(secs, *raw)
+        assert f"{obs:{fmt}}" == csv.format(secs, *data)
     elif fmt == "cf":
         cf = "{}: CF1 {:.0%}, CF2.5 {:.0%}, CF10 {:.0%}"
-        assert f"{obs:{fmt}}" == cf.format(date, raw[3] / raw[0], raw[4] / raw[1], raw[5] / raw[2])
+        assert f"{obs:{fmt}}" == cf.format(
+            date, data[3] / data[0], data[4] / data[1], data[5] / data[2]
+        )
     else:
         with pytest.raises(ValueError) as e:
             f"{obs:{fmt}}"
@@ -38,12 +40,12 @@ def test_PMSx003_format(fmt, raw=tuple(range(1, 13)), secs=1_567_198_523, sensor
 
 
 @pytest.mark.parametrize("fmt", "header csv pm num cf raw hcho atm error".split())
-def test_PMS5003ST_format(fmt, raw=list(range(1, 16)), secs=1_567_198_523, sensor=pms5003st):
-    obs = sensor.ObsData(secs, *raw)
-    raw[6:12] = [x / 100 for x in raw[6:12]]
-    raw[12] /= 1000
-    raw[13] /= 10
-    raw[14] /= 10
+def test_PMS5003ST_format(fmt, data=list(range(1, 16)), secs=1_567_198_523, sensor=pms5003st):
+    obs = sensor.ObsData(secs, *data)
+    data[6:12] = [x / 100 for x in data[6:12]]
+    data[12] /= 1000
+    data[13] /= 10
+    data[14] /= 10
     obs_fmt = dict(
         raw="{0}: PM1 {1:d}, PM2.5 {2:d}, PM10 {3:d} μg/m3",
         pm="{0}: PM1 {4:.1f}, PM2.5 {5:.1f}, PM10 {6:.1f} μg/m3",
@@ -53,15 +55,17 @@ def test_PMS5003ST_format(fmt, raw=list(range(1, 16)), secs=1_567_198_523, senso
     )
     date = time.strftime("%F %T", time.localtime(secs))
     if fmt in obs_fmt:
-        assert f"{obs:{fmt}}" == obs_fmt[fmt].format(date, *raw)
+        assert f"{obs:{fmt}}" == obs_fmt[fmt].format(date, *data)
     elif fmt == "header":
         assert f"{obs:{fmt}}" == ", ".join(asdict(obs).keys())
     elif fmt == "csv":
         csv = "{}, {:d}, {:d}, {:d}, {:.1f}, {:.1f}, {:.1f}, {:.2f}, {:.2f}, {:.2f}, {:.2f}, {:.2f}, {:.2f}, {:.3f}, {:.1f}, {:.1f}"
-        assert f"{obs:{fmt}}" == csv.format(secs, *raw)
+        assert f"{obs:{fmt}}" == csv.format(secs, *data)
     elif fmt == "cf":
         cf = "{}: CF1 {:.0%}, CF2.5 {:.0%}, CF10 {:.0%}"
-        assert f"{obs:{fmt}}" == cf.format(date, raw[3] / raw[0], raw[4] / raw[1], raw[5] / raw[2])
+        assert f"{obs:{fmt}}" == cf.format(
+            date, data[3] / data[0], data[4] / data[1], data[5] / data[2]
+        )
     else:
         with pytest.raises(ValueError) as e:
             f"{obs:{fmt}}"
@@ -69,9 +73,9 @@ def test_PMS5003ST_format(fmt, raw=list(range(1, 16)), secs=1_567_198_523, senso
 
 
 @pytest.mark.parametrize("fmt", "header csv pm num cf raw atm error".split())
-def test_PMS5003T_format(fmt, raw=tuple(range(1, 13)), secs=1_567_198_523, sensor=pms5003t):
-    obs = sensor.ObsData(secs, *raw)
-    raw = raw[:6] + tuple(x / 100 for x in raw[6:-2]) + tuple(x / 10 for x in raw[-2:])
+def test_PMS5003T_format(fmt, data=tuple(range(1, 13)), secs=1_567_198_523, sensor=pms5003t):
+    obs = sensor.ObsData(secs, *data)
+    data = data[:6] + tuple(x / 100 for x in data[6:-2]) + tuple(x / 10 for x in data[-2:])
     obs_fmt = dict(
         raw="{0}: PM1 {1:d}, PM2.5 {2:d}, PM10 {3:d} μg/m3",
         pm="{0}: PM1 {4:.1f}, PM2.5 {5:.1f}, PM10 {6:.1f} μg/m3",
@@ -80,15 +84,17 @@ def test_PMS5003T_format(fmt, raw=tuple(range(1, 13)), secs=1_567_198_523, senso
     )
     date = time.strftime("%F %T", time.localtime(secs))
     if fmt in obs_fmt:
-        assert f"{obs:{fmt}}" == obs_fmt[fmt].format(date, *raw)
+        assert f"{obs:{fmt}}" == obs_fmt[fmt].format(date, *data)
     elif fmt == "header":
         assert f"{obs:{fmt}}" == ", ".join(asdict(obs).keys())
     elif fmt == "csv":
         csv = "{}, {:d}, {:d}, {:d}, {:.1f}, {:.1f}, {:.1f}, {:.2f}, {:.2f}, {:.2f}, {:.2f}, {:.1f}, {:.1f}"
-        assert f"{obs:{fmt}}" == csv.format(secs, *raw)
+        assert f"{obs:{fmt}}" == csv.format(secs, *data)
     elif fmt == "cf":
         cf = "{}: CF1 {:.0%}, CF2.5 {:.0%}, CF10 {:.0%}"
-        assert f"{obs:{fmt}}" == cf.format(date, raw[3] / raw[0], raw[4] / raw[1], raw[5] / raw[2])
+        assert f"{obs:{fmt}}" == cf.format(
+            date, data[3] / data[0], data[4] / data[1], data[5] / data[2]
+        )
     else:
         with pytest.raises(ValueError) as e:
             f"{obs:{fmt}}"
@@ -96,20 +102,20 @@ def test_PMS5003T_format(fmt, raw=tuple(range(1, 13)), secs=1_567_198_523, senso
 
 
 @pytest.mark.parametrize("fmt", "header csv pm error".split())
-def test_SDS01x_format(fmt, raw=(11, 12), secs=1_567_198_523, sensor=sds01x):
-    obs = sensor.ObsData(secs, *raw)
-    raw = tuple(r / 10 for r in raw)
+def test_SDS01x_format(fmt, data=(11, 12), secs=1_567_198_523, sensor=sds01x):
+    obs = sensor.ObsData(secs, *data)
+    data = tuple(r / 10 for r in data)
     obs_fmt = dict(
         pm="{}: PM2.5 {:.1f}, PM10 {:.1f} μg/m3",
     )
     date = time.strftime("%F %T", time.localtime(secs))
     if fmt in obs_fmt:
-        assert f"{obs:{fmt}}" == obs_fmt[fmt].format(date, *raw)
+        assert f"{obs:{fmt}}" == obs_fmt[fmt].format(date, *data)
     elif fmt == "header":
         assert f"{obs:{fmt}}" == ", ".join(asdict(obs).keys())
     elif fmt == "csv":
         csv = "{}, {:.1f}, {:.1f}"
-        assert f"{obs:{fmt}}" == csv.format(secs, *raw)
+        assert f"{obs:{fmt}}" == csv.format(secs, *data)
     else:
         with pytest.raises(ValueError) as e:
             f"{obs:{fmt}}"
@@ -117,19 +123,19 @@ def test_SDS01x_format(fmt, raw=(11, 12), secs=1_567_198_523, sensor=sds01x):
 
 
 @pytest.mark.parametrize("fmt", "header csv pm error".split())
-def test_SDS198_format(fmt, raw=123, secs=1_567_198_523, sensor=sds198):
-    obs = sensor.ObsData(secs, raw)
+def test_SDS198_format(fmt, data=123, secs=1_567_198_523, sensor=sds198):
+    obs = sensor.ObsData(secs, data)
     obs_fmt = dict(
         pm="{}: PM100 {:.1f} μg/m3",
     )
     date = time.strftime("%F %T", time.localtime(secs))
     if fmt in obs_fmt:
-        assert f"{obs:{fmt}}" == obs_fmt[fmt].format(date, raw)
+        assert f"{obs:{fmt}}" == obs_fmt[fmt].format(date, data)
     elif fmt == "header":
         assert f"{obs:{fmt}}" == ", ".join(asdict(obs).keys())
     elif fmt == "csv":
         csv = "{}, {:.1f}"
-        assert f"{obs:{fmt}}" == csv.format(secs, raw)
+        assert f"{obs:{fmt}}" == csv.format(secs, data)
     else:
         with pytest.raises(ValueError) as e:
             f"{obs:{fmt}}"
@@ -137,19 +143,19 @@ def test_SDS198_format(fmt, raw=123, secs=1_567_198_523, sensor=sds198):
 
 
 @pytest.mark.parametrize("fmt", "header csv pm error".split())
-def test_HPMA115S0_format(fmt, raw=(11, 12), secs=1_567_198_523, sensor=hpma115s0):
-    obs = sensor.ObsData(secs, *raw)
+def test_HPMA115S0_format(fmt, data=(11, 12), secs=1_567_198_523, sensor=hpma115s0):
+    obs = sensor.ObsData(secs, *data)
     obs_fmt = dict(
         pm="{}: PM2.5 {:.1f}, PM10 {:.1f} μg/m3",
     )
     date = time.strftime("%F %T", time.localtime(secs))
     if fmt in obs_fmt:
-        assert f"{obs:{fmt}}" == obs_fmt[fmt].format(date, *raw)
+        assert f"{obs:{fmt}}" == obs_fmt[fmt].format(date, *data)
     elif fmt == "header":
         assert f"{obs:{fmt}}" == ", ".join(asdict(obs).keys())
     elif fmt == "csv":
         csv = "{}, {:.1f}, {:.1f}"
-        assert f"{obs:{fmt}}" == csv.format(secs, *raw)
+        assert f"{obs:{fmt}}" == csv.format(secs, *data)
     else:
         with pytest.raises(ValueError) as e:
             f"{obs:{fmt}}"
@@ -157,19 +163,19 @@ def test_HPMA115S0_format(fmt, raw=(11, 12), secs=1_567_198_523, sensor=hpma115s
 
 
 @pytest.mark.parametrize("fmt", "header csv pm error".split())
-def test_HPMA115C0_format(fmt, raw=(11, 12, 13, 14), secs=1_567_198_523, sensor=hpma115c0):
-    obs = sensor.ObsData(secs, *raw)
+def test_HPMA115C0_format(fmt, data=(11, 12, 13, 14), secs=1_567_198_523, sensor=hpma115c0):
+    obs = sensor.ObsData(secs, *data)
     obs_fmt = dict(
         pm="{}: PM1 {:.1f}, PM2.5 {:.1f}, PM4 {:.1f}, PM10 {:.1f} μg/m3",
     )
     date = time.strftime("%F %T", time.localtime(secs))
     if fmt in obs_fmt:
-        assert f"{obs:{fmt}}" == obs_fmt[fmt].format(date, *raw)
+        assert f"{obs:{fmt}}" == obs_fmt[fmt].format(date, *data)
     elif fmt == "header":
         assert f"{obs:{fmt}}" == ", ".join(asdict(obs).keys())
     elif fmt == "csv":
         csv = "{}, {:.1f}, {:.1f}, {:.1f}, {:.1f}"
-        assert f"{obs:{fmt}}" == csv.format(secs, *raw)
+        assert f"{obs:{fmt}}" == csv.format(secs, *data)
     else:
         with pytest.raises(ValueError) as e:
             f"{obs:{fmt}}"
@@ -177,8 +183,8 @@ def test_HPMA115C0_format(fmt, raw=(11, 12, 13, 14), secs=1_567_198_523, sensor=
 
 
 @pytest.mark.parametrize("fmt", "header csv pm num diam error".split())
-def test_SPS30_format(fmt, raw=range(100, 110), secs=1_567_198_523, sensor=sps30):
-    obs = sensor.ObsData(secs, *raw)
+def test_SPS30_format(fmt, data=range(100, 110), secs=1_567_198_523, sensor=sps30):
+    obs = sensor.ObsData(secs, *data)
     obs_fmt = dict(
         pm="{0}: PM1 {1:.1f}, PM2.5 {2:.1f}, PM4 {3:.1f}, PM10 {4:.1f} μg/m3",
         num="{0}: N0.5 {5:.2f}, N1.0 {6:.2f}, N2.5 {7:.2f}, N4.0 {8:.2f}, N10 {9:.2f} #/cm3",
@@ -186,12 +192,12 @@ def test_SPS30_format(fmt, raw=range(100, 110), secs=1_567_198_523, sensor=sps30
     )
     date = time.strftime("%F %T", time.localtime(secs))
     if fmt in obs_fmt:
-        assert f"{obs:{fmt}}" == obs_fmt[fmt].format(date, *raw)
+        assert f"{obs:{fmt}}" == obs_fmt[fmt].format(date, *data)
     elif fmt == "header":
         assert f"{obs:{fmt}}" == ", ".join(asdict(obs).keys())
     elif fmt == "csv":
         csv = "{}, {:.1f}, {:.1f}, {:.1f}, {:.1f}, {:.2f}, {:.2f}, {:.2f}, {:.2f}, {:.2f}, {:.1f}"
-        assert f"{obs:{fmt}}" == csv.format(secs, *raw)
+        assert f"{obs:{fmt}}" == csv.format(secs, *data)
     else:
         with pytest.raises(ValueError) as e:
             f"{obs:{fmt}}"
@@ -199,14 +205,14 @@ def test_SPS30_format(fmt, raw=range(100, 110), secs=1_567_198_523, sensor=sps30
 
 
 @pytest.mark.parametrize("fmt", "header csv atm bme bsec error".split())
-def test_mcu680_format(fmt, raw=list(range(100, 107)), secs=1_567_198_523, sensor=mcu680):
-    obs = sensor.ObsData(secs, *raw)
-    raw[0] /= 100
-    raw[1] /= 100
-    raw[2] = (int(raw[2]) << 8 | raw[3]) / 100
-    raw[3] = raw[4] >> 4
-    raw[4] &= 0x0FFF
-    raw[5] /= 1000
+def test_mcu680_format(fmt, data=list(range(100, 107)), secs=1_567_198_523, sensor=mcu680):
+    obs = sensor.ObsData(secs, *data)
+    data[0] /= 100
+    data[1] /= 100
+    data[2] = (int(data[2]) << 8 | data[3]) / 100
+    data[3] = data[4] >> 4
+    data[4] &= 0x0FFF
+    data[5] /= 1000
     obs_fmt = dict(
         atm="{0}: Temp. {1:.1f} °C, Rel.Hum. {2:.1f} %, Press {3:.2f} hPa",
         bsec="{0}: Temp. {1:.1f} °C, Rel.Hum. {2:.1f} %, Press {3:.2f} hPa, {5} IAQ",
@@ -214,12 +220,12 @@ def test_mcu680_format(fmt, raw=list(range(100, 107)), secs=1_567_198_523, senso
     )
     date = time.strftime("%F %T", time.localtime(secs))
     if fmt in obs_fmt:
-        assert f"{obs:{fmt}}" == obs_fmt[fmt].format(date, *raw)
+        assert f"{obs:{fmt}}" == obs_fmt[fmt].format(date, *data)
     elif fmt == "header":
         assert f"{obs:{fmt}}" == ", ".join(asdict(obs).keys())
     elif fmt == "csv":
         csv = "{}, {:.1f}, {:.1f}, {:.2f}, {:}, {:}, {:.1f}, {:}"
-        assert f"{obs:{fmt}}" == csv.format(secs, *raw)
+        assert f"{obs:{fmt}}" == csv.format(secs, *data)
     else:
         with pytest.raises(ValueError) as e:
             f"{obs:{fmt}}"
@@ -227,19 +233,19 @@ def test_mcu680_format(fmt, raw=list(range(100, 107)), secs=1_567_198_523, senso
 
 
 @pytest.mark.parametrize("fmt", "header co2 csv error".split())
-def test_mhz19b_format(fmt, raw=(500,), secs=1_567_198_523, sensor=mhz19b):
-    obs = sensor.ObsData(secs, *raw)
+def test_mhz19b_format(fmt, data=(500,), secs=1_567_198_523, sensor=mhz19b):
+    obs = sensor.ObsData(secs, *data)
     obs_fmt = dict(
         co2="{0}: CO2 {1} ppm",
     )
     date = time.strftime("%F %T", time.localtime(secs))
     if fmt in obs_fmt:
-        assert f"{obs:{fmt}}" == obs_fmt[fmt].format(date, *raw)
+        assert f"{obs:{fmt}}" == obs_fmt[fmt].format(date, *data)
     elif fmt == "header":
         assert f"{obs:{fmt}}" == ", ".join(asdict(obs).keys())
     elif fmt == "csv":
         csv = "{}, {}"
-        assert f"{obs:{fmt}}" == csv.format(secs, *raw)
+        assert f"{obs:{fmt}}" == csv.format(secs, *data)
     else:
         with pytest.raises(ValueError) as e:
             f"{obs:{fmt}}"
@@ -247,19 +253,19 @@ def test_mhz19b_format(fmt, raw=(500,), secs=1_567_198_523, sensor=mhz19b):
 
 
 @pytest.mark.parametrize("fmt", "header csv pm error".split())
-def test_ZH0xx_format(fmt, raw=(133, 150, 101), secs=1_567_198_523, sensor=zh0xx):
-    obs = sensor.ObsData(secs, *raw)
+def test_ZH0xx_format(fmt, data=(133, 150, 101), secs=1_567_198_523, sensor=zh0xx):
+    obs = sensor.ObsData(secs, *data)
     obs_fmt = dict(
         pm="{0}: PM1 {3:.1f}, PM2.5 {1:.1f}, PM10 {2:.1f} μg/m3",
     )
     date = time.strftime("%F %T", time.localtime(secs))
     if fmt in obs_fmt:
-        assert f"{obs:{fmt}}" == obs_fmt[fmt].format(date, *raw)
+        assert f"{obs:{fmt}}" == obs_fmt[fmt].format(date, *data)
     elif fmt == "header":
         assert f"{obs:{fmt}}" == ", ".join(asdict(obs).keys())
     elif fmt == "csv":
         csv = "{0}, {3:.1f}, {1:.1f}, {2:.1f}"
-        assert f"{obs:{fmt}}" == csv.format(secs, *raw)
+        assert f"{obs:{fmt}}" == csv.format(secs, *data)
     else:
         with pytest.raises(ValueError) as e:
             f"{obs:{fmt}}"


### PR DESCRIPTION
Using "data" is consistent with the actual parameter name in the ObsData protocol and avoids confusion of actual "raw" data - a byte sequence - with decoded data (a list of floats).