### PR TITLE
Improve coverage for reader classes

### DIFF
--- a/src/pms/core/reader.py
+++ b/src/pms/core/reader.py
@@ -173,7 +173,7 @@ class SensorReader(Reader):
                     sample += 1
                     if self.samples is not None and sample >= self.samples:
                         break
-                    if self.interval:  # pragma: no cover
+                    if self.interval:
                         delay = self.interval - (time.time() - obs.time)
                         if delay > 0:
                             time.sleep(delay)

--- a/src/pms/core/reader.py
+++ b/src/pms/core/reader.py
@@ -162,7 +162,7 @@ class SensorReader(Reader):
 
                 try:
                     obs = self.sensor.decode(buffer)
-                except (SensorWarmingUp, InconsistentObservation) as e:  # pragma: no cover
+                except (SensorWarmingUp, InconsistentObservation) as e:
                     logger.debug(e)
                     time.sleep(5)
                 except SensorWarning as e:  # pragma: no cover

--- a/src/pms/core/reader.py
+++ b/src/pms/core/reader.py
@@ -134,12 +134,12 @@ class SensorReader(Reader):
         logger.debug(f"buffer length: {len(buffer)}")
 
         # check if the sensor answered
-        if len(buffer) == 0:  # pragma: no cover
+        if len(buffer) == 0:
             logger.error(f"Sensor did not respond, check UART pin connections")
             raise UnableToRead("Sensor did not respond")
 
         # check against sensor type derived from buffer
-        if not self.sensor.check(buffer, "passive_mode"):  # pragma: no cover
+        if not self.sensor.check(buffer, "passive_mode"):
             logger.error(f"Sensor is not {self.sensor.name}")
             raise UnableToRead("Sensor failed validation")
 

--- a/src/pms/core/reader.py
+++ b/src/pms/core/reader.py
@@ -203,7 +203,7 @@ class MessageReader(Reader):
         for row in self.data:
             time, message = int(row["time"]), bytes.fromhex(row["hex"])
             yield RawData(time, message) if raw else self.sensor.decode(message, time=time)
-            if self.samples:  # pragma: no cover
+            if self.samples:
                 self.samples -= 1
                 if self.samples <= 0:
                     break

--- a/src/pms/core/reader.py
+++ b/src/pms/core/reader.py
@@ -200,6 +200,9 @@ class MessageReader(Reader):
         self.csv.close()
 
     def __call__(self, *, raw: Optional[bool] = None):
+        if not hasattr(self, "data"):
+            return
+
         for row in self.data:
             time, message = int(row["time"]), bytes.fromhex(row["hex"])
             yield RawData(time, message) if raw else self.sensor.decode(message, time=time)

--- a/src/pms/core/reader.py
+++ b/src/pms/core/reader.py
@@ -93,7 +93,7 @@ class SensorReader(Reader):
             f"from {port} every {interval if interval else '?'} secs"
         )
 
-    def _cmd(self, command: str) -> bytes:  # pragma: no cover
+    def _cmd(self, command: str) -> bytes:
         """Write command to sensor and return answer"""
 
         # send command
@@ -101,7 +101,7 @@ class SensorReader(Reader):
         if cmd.command:
             self.serial.write(cmd.command)
             self.serial.flush()
-        elif command.endswith("read"):
+        elif command.endswith("read"):  # pragma: no cover
             self.serial.reset_input_buffer()
 
         # return full buffer

--- a/src/pms/core/reader.py
+++ b/src/pms/core/reader.py
@@ -107,7 +107,7 @@ class SensorReader(Reader):
         # return full buffer
         return self.serial.read(max(cmd.answer_length, self.serial.in_waiting))
 
-    def _pre_heat(self):  # pragma: no cover
+    def _pre_heat(self):
         if not self.pre_heat:
             return
 

--- a/src/pms/core/reader.py
+++ b/src/pms/core/reader.py
@@ -51,16 +51,13 @@ class RawData(NamedTuple):
 
 
 class Reader(AbstractContextManager):
-    @overload
-    def __call__(self) -> Iterator[ObsData]:
-        ...
-
-    @overload
-    def __call__(self, *, raw: bool) -> Iterator[RawData]:
-        ...
-
     @abstractmethod
-    def __call__(self, *, raw: Optional[bool] = None):
+    def __call__(self, *, raw: Optional[bool]) -> Iterator[Union[RawData, ObsData]]:
+        """
+        Return an iterator of ObsData.
+
+        If "raw" is set to True, then ObsData is replaced with RawData.
+        """
         ...
 
 

--- a/tests/core/test_reader.py
+++ b/tests/core/test_reader.py
@@ -138,6 +138,24 @@ def test_sensor_reader_sleep(mock_sensor, monkeypatch, mock_sleep):
     assert 0 < mock_sleep.slept_for < 5
 
 
+def test_sensor_reader_closed(mock_sensor, monkeypatch):
+    sensor_reader = reader.SensorReader(
+        port=mock_sensor.port,
+        sensor="PMSx003",  # match with stubs
+        timeout=0.01,  # low to avoid hanging on failure
+    )
+
+    # https://github.com/pyserial/pyserial/issues/625
+    monkeypatch.setattr(
+        sensor_reader.serial,
+        "flush",
+        lambda: None,
+    )
+
+    obs = list(sensor_reader())
+    assert len(obs) == 0
+
+
 def test_sensor_reader_preheat(mock_sensor, monkeypatch, mock_sleep):
     sensor_reader = reader.SensorReader(
         port=mock_sensor.port,

--- a/tests/core/test_reader.py
+++ b/tests/core/test_reader.py
@@ -1,6 +1,8 @@
 import pytest
 
 from pms.core import reader
+from pms.core.sensor import Sensor
+from tests.conftest import captured_data
 
 
 class MockReader(reader.Reader):
@@ -162,3 +164,15 @@ def test_exit_on_fail_error(monkeypatch):
             raise Exception("should not get here")
 
     assert "exit" in str(e.value)
+
+
+def test_message_reader():
+    message_reader = reader.MessageReader(
+        path=captured_data,
+        sensor=Sensor["PMS3003"],
+    )
+
+    with message_reader:
+        values = list(message_reader())
+
+    assert len(values) == 10

--- a/tests/core/test_reader.py
+++ b/tests/core/test_reader.py
@@ -313,3 +313,13 @@ def test_message_reader():
         values = list(message_reader())
 
     assert len(values) == 10
+
+
+def test_message_reader_closed():
+    message_reader = reader.MessageReader(
+        path=captured_data,
+        sensor=Sensor["PMS3003"],
+    )
+
+    values = list(message_reader())
+    assert len(values) == 0

--- a/tests/core/test_reader.py
+++ b/tests/core/test_reader.py
@@ -138,6 +138,30 @@ def test_sensor_reader_sleep(mock_sensor, monkeypatch, mock_sleep):
     assert 0 < mock_sleep.slept_for < 5
 
 
+def test_sensor_reader_preheat(mock_sensor, monkeypatch, mock_sleep):
+    sensor_reader = reader.SensorReader(
+        port=mock_sensor.port,
+        sensor="PMSx003",  # match with stubs
+        timeout=0.01,  # low to avoid hanging on failure
+    )
+
+    # https://github.com/pyserial/pyserial/issues/625
+    monkeypatch.setattr(
+        sensor_reader.serial,
+        "flush",
+        lambda: None,
+    )
+
+    # override pre heat duration
+    sensor_reader.pre_heat = 5
+
+    with sensor_reader as r:
+        pass
+
+    # check we slept between reads
+    assert mock_sleep.slept_for == 5
+
+
 def test_sensor_reader_sensor_mismatch(mock_sensor, monkeypatch):
     sensor_reader = reader.SensorReader(
         port=mock_sensor.port,


### PR DESCRIPTION
Follows on  from: https://github.com/avaldebe/PyPMS/pull/29

In attempting to refactor the reader classes I found it 
useful to have even more tests than those I proposed 
previously. Rather than have a huge "refactoring" PR 
I thought it would be better to propose them first.

Note: the first commit isn't related to coverage but is 
also a bit tangential to the refactoring, so added here.