### PR TITLE
Enable pre-heat for PMSx003 sensors

### DIFF
--- a/src/pms/sensors/plantower/pmsx003.py
+++ b/src/pms/sensors/plantower/pmsx003.py
@@ -13,6 +13,7 @@ from . import pms3003
 
 ALIASES = ("PMS1003", "G1", "PMS5003", "G5", "PMS7003", "G7", "PMSA003", "G10")
 
+PREHEAT = 10  # 10 seconds
 
 commands = base.Commands(
     passive_read=base.Cmd(b"\x42\x4D\xE2\x00\x00\x01\x71", b"\x42\x4D\x00\x1c", 32),

--- a/tests/core/test_reader.py
+++ b/tests/core/test_reader.py
@@ -158,6 +158,8 @@ def sensor_reader_factory(monkeypatch, mock_sensor):
             lambda: None,
         )
 
+        sensor_reader.pre_heat = 0  # disable any preheat
+
         return sensor_reader
 
     return factory

--- a/tests/sensors/test_sensor.py
+++ b/tests/sensors/test_sensor.py
@@ -29,7 +29,12 @@ def test_baud(sensor):
 
 @pytest.mark.parametrize("sensor", Supported)
 def test_pre_heat(sensor):
-    pre_heat = 0 if sensor != "MHZ19B" else 180
+    if sensor == "MHZ19B":
+        pre_heat = 180
+    elif sensor == "PMSx003":
+        pre_heat = 10
+    else:
+        pre_heat = 0
     assert Sensor[sensor].pre_heat == pre_heat
 
 


### PR DESCRIPTION
The PMSA003 sensor takes approximately 10 seconds to warm up, with 
InconsistentObservation and WrongMessageFormat exceptions raised 
for earlier samples. From experimentation, 10 seconds is almost exactly 
the warm up time, but the datasheet actually recommends 30s [^1]:

    Stable data should be got at least 30 seconds after the sensor wakeup from the sleep mode because of the fan’s performance.

However, it makes sense to set this number based on what happens in 
practice; we can always increase if others observe worse behaviour.

[^1]: https://cdn.shopify.com/s/files/1/0176/3274/files/PMSA003_datasheet.pdf?v=1619703