### PR TITLE
Disable logging unless code is running in CLI

### DIFF
--- a/src/pms/__init__.py
+++ b/src/pms/__init__.py
@@ -1,3 +1,8 @@
+from loguru import logger
+
+logger.disable("pms")  # disable logging by default
+
+
 class SensorWarning(UserWarning):
     """Recoverable errors"""
 

--- a/src/pms/cli.py
+++ b/src/pms/cli.py
@@ -25,7 +25,8 @@ for ep in metadata.entry_points(group="pypms.extras"):
     app.command(name=ep.name)(ep.load())
 
 
-def main():
+def main():  # pragma: no cover
+    logger.enable("pms")
     app()
 
 

--- a/tests/extra/test_cli.py
+++ b/tests/extra/test_cli.py
@@ -39,9 +39,9 @@ def mock_mqtt(monkeypatch):
 
 def test_mqtt(capture, mock_mqtt):
 
-    from pms.cli import main
+    from pms.cli import app
 
-    result = runner.invoke(main, capture.options("mqtt"))
+    result = runner.invoke(app, capture.options("mqtt"))
     assert result.exit_code == 0
 
 
@@ -62,9 +62,9 @@ def mock_influxdb(monkeypatch):
 
 def test_influxdb(capture, mock_influxdb):
 
-    from pms.cli import main
+    from pms.cli import app
 
-    result = runner.invoke(main, capture.options("influxdb"))
+    result = runner.invoke(app, capture.options("influxdb"))
     assert result.exit_code == 0
 
 
@@ -110,8 +110,8 @@ def mock_bridge(monkeypatch, capture_data):
 
 def test_bridge(mock_bridge):
 
-    from pms.cli import main
+    from pms.cli import app
 
     capture = mock_bridge
-    result = runner.invoke(main, capture.options("bridge"))
+    result = runner.invoke(app, capture.options("bridge"))
     assert result.exit_code == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,18 +9,18 @@ runner = CliRunner()
 @pytest.mark.parametrize("format", {"csv", "hexdump"})
 def test_serial(capture, format):
 
-    from pms.cli import main
+    from pms.cli import app
 
-    result = runner.invoke(main, capture.options(f"serial_{format}"))
+    result = runner.invoke(app, capture.options(f"serial_{format}"))
     assert result.exit_code == 0
     assert result.stdout == capture.output(format)
 
 
 def test_csv(capture):
 
-    from pms.cli import main
+    from pms.cli import app
 
-    result = runner.invoke(main, capture.options("csv"))
+    result = runner.invoke(app, capture.options("csv"))
     assert result.exit_code == 0
 
     csv = Path(capture.options("csv")[-1])
@@ -31,15 +31,15 @@ def test_csv(capture):
 
 def test_capture_decode(capture):
 
-    from pms.cli import main
+    from pms.cli import app
 
-    result = runner.invoke(main, capture.options("capture"))
+    result = runner.invoke(app, capture.options("capture"))
     assert result.exit_code == 0
 
     csv = Path(capture.options("capture")[-1])
     assert csv.exists()
 
-    result = runner.invoke(main, capture.options("decode"))
+    result = runner.invoke(app, capture.options("decode"))
     assert result.exit_code == 0
     csv.unlink()
     assert result.stdout == capture.output("csv")


### PR DESCRIPTION
Fixes regression from [^1].

Previously this repo used Python's inbuilt logger, which does 
not emit INFO or DEBUG logs by default. loguru emits all logs 
by default. This fixes that by disabling loguru unless the code 
is running in CLI mode, which is when logs are actually used.

[^1]: https://github.com/avaldebe/PyPMS/commit/ecd0c9d1cd0e88284299fecc6416f5f01cadf10d